### PR TITLE
dm-instagib.cfg : block Demoman

### DIFF
--- a/tf/cfg/servers/dm_instagib.cfg
+++ b/tf/cfg/servers/dm_instagib.cfg
@@ -14,7 +14,7 @@ mapcyclefile "servers/dm/dm_ig_mapcycle.txt"
 
 
 
-sm_classrestrict_blu_demomen 16
+sm_classrestrict_blu_demomen 0
 sm_classrestrict_blu_engineers 0
 sm_classrestrict_blu_heavies 0
 sm_classrestrict_blu_medics 0
@@ -23,7 +23,7 @@ sm_classrestrict_blu_scouts 0
 sm_classrestrict_blu_snipers 0
 sm_classrestrict_blu_soldiers 16
 sm_classrestrict_blu_spies 0
-sm_classrestrict_red_demomen 16
+sm_classrestrict_red_demomen 0
 sm_classrestrict_red_engineers 0
 sm_classrestrict_red_heavies 0
 sm_classrestrict_red_medics 0


### PR DESCRIPTION
Demoman is not intended to be pickable at the moment pending a potential handling for how Demoman should work in RIG.